### PR TITLE
Update outdated terminology in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ You may also be interested in manually installing these optional extensions:
 
 ## Configuration
 
-The following configuration is recommended (<kbd>F1</kbd> → `Preferences: Open Settings (JSON)`):
+The following configuration is recommended (<kbd>F1</kbd> → `Preferences: Open User Settings (JSON)`):
 
 ```json
     "Lua.runtime.version": "Lua 5.2",


### PR DESCRIPTION
"Preferences: Open Settings (JSON)" in newer versions of VSCode and VSCodium is now called "Preferences: Open User Settings (JSON)"
This closes https://github.com/Lemmmy/computercraft-extension-pack/issues/2